### PR TITLE
Fix int-to-int type conversion

### DIFF
--- a/src/mjolnir/ssa_rules.clj
+++ b/src/mjolnir/ssa_rules.clj
@@ -271,7 +271,7 @@
 
 ;; Binop rules - These rules define an attribute that helps emitters
 ;; decide if a binop is a Float or Int operation. FMul is different
-;; from IMul, so this code specializes that information. 
+;; from IMul, so this code specializes that information.
 
 (comment
   (defrule infer-binop [?id ?op]
@@ -305,18 +305,18 @@
   "Larger Ints truncate to smaller ints"
   [?arg0-t :node/type :type/int]
   [?arg1-t :node/type :type/int]
-  [?arg0-t :type/length ?arg0-length]
-  [?arg1-t :type/length ?arg1-length]
-  [(> ?arg0-length ?arg1-length)]
+  [?arg0-t :type/width ?arg0-width]
+  [?arg1-t :type/width ?arg1-width]
+  [(> ?arg0-width ?arg1-width)]
   [(identity :inst.cast.type/trunc) ?op])
 
 (defrule cast-subtype [?id ?arg0-t ?arg1-t ?op]
-  "Larger Ints truncate to smaller ints"
+  "Smaller ints upcast to larger ints"
   [?arg0-t :node/type :type/int]
   [?arg1-t :node/type :type/int]
-  [?arg0-t :type/length ?arg0-length]
-  [?arg1-t :type/length ?arg1-length]
-  [(< ?arg0-length ?arg1-length)]
+  [?arg0-t :type/width ?arg0-width]
+  [?arg1-t :type/width ?arg1-width]
+  [(< ?arg0-width ?arg1-width)]
   [(identity :inst.cast.type/zext) ?op])
 
 (defrule cast-subtype [?id ?arg0-t ?arg1-t ?op]


### PR DESCRIPTION
Take the following (contrived) example of a type cast:

``` clj
(c/cast Int64 (c/+ (c/const 1 -> Int32) (c/const 2 -> Int32)))
```

This code exemplifies an issue where trying to cast from any one int type to another would cause the following stack trace to show up:

```
Remaining nodes...
#{["thing"] ["identity"] ["my-rand"] ["main"] ["rand"] ["my-fn"] ["user/-main"]}
[:inst.type/cast :inst.cast/type :type/int :type/int :inst.type/binop nil "rand" {:fn/name "rand", :db/id 17592186045427}]
Exception in thread "main" java.lang.AssertionError: Assert failed: inference fails
false
    at mjolnir.inference$infer_all.invoke(inference.clj:100)
    at mjolnir.core$to_llvm_module.invoke(core.clj:31)
    ...
```

This was due to a typo in `ssa_rules.clj`, where the (non-existent) field `:type/length` was erroneously used instead of the proper `:type/width` for comparing int sizes
